### PR TITLE
Added Github Stats and most used langauges command

### DIFF
--- a/bot/cogs/github.py
+++ b/bot/cogs/github.py
@@ -11,6 +11,9 @@ from config.common import config
 from config.oauth import github_oauth_config
 from models import UserModel
 
+from svglib.svglib import svg2rlg
+from reportlab.graphics import renderPM
+import io
 
 class GithubNotLinkedError(commands.CommandError):
     def __str__(self):
@@ -121,7 +124,23 @@ class Github(commands.Cog):
         )
 
         await ctx.send(embed=em)
+        
+        
+    @commands.command(name="githubstats", aliases=["ghstats", "ghst"])
+    async def github_stats(ctx,username = "codewithswastik",theme="radical"):
+        theme = theme.lower()
+        themes = "default dark radical merko gruvbox tokyonight onedark cobalt synthwave highcontrast dracula".split(" ")
+        if theme not in themes:
+            return await ctx.send("Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula")
+        url = f"https://github-readme-stats.codestackr.vercel.app/api?username={username}&show_icons=true&hide_border=true&theme={theme}"
+        res = await (await self.session.get(url)).content.read()
 
+        clean_res = res.replace(b"A+",b"") #removes the uncentered A+
+        drawing = svg2rlg(BytesIO(clean_res))
+        file = BytesIO(renderPM.drawToString(drawing, fmt="PNG"))
+        await ctx.send(file = discord.File(file,filename="stats.png"))
+
+        
     @staticmethod
     def repo_desc_format(result):
         description = result["description"]

--- a/bot/cogs/github.py
+++ b/bot/cogs/github.py
@@ -13,7 +13,7 @@ from models import UserModel
 
 from svglib.svglib import svg2rlg
 from reportlab.graphics import renderPM
-import io
+from io import BytesIO
 
 class GithubNotLinkedError(commands.CommandError):
     def __str__(self):

--- a/bot/cogs/github.py
+++ b/bot/cogs/github.py
@@ -127,49 +127,58 @@ class Github(commands.Cog):
         
         
     @commands.command(name="githubstats", aliases=["ghstats", "ghst"])
-    async def github_stats(self,ctx,username = "codewithswastik",theme="radical"):
+    async def github_stats(self, ctx, username="codewithswastik", theme="radical"):
         theme = theme.lower()
-        themes = "default dark radical merko gruvbox tokyonight onedark cobalt synthwave highcontrast dracula".split(" ")
+        themes = "default dark radical merko gruvbox tokyonight onedark cobalt synthwave highcontrast dracula".split(
+            " "
+        )
         if theme not in themes:
-            return await ctx.send("Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula")
+            return await ctx.send(
+                "Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula"
+            )
         url = "https://github-readme-stats.codestackr.vercel.app/api?" + urlencode(
             {
                 "username": username,
                 "show_icons": "true",
                 "hide_border": "true",
-                "theme":theme
+                "theme": theme,
             }
         )
-        
-        
+
         url = f"https://github-readme-stats.codestackr.vercel.app/api?username={username}&show_icons=true&hide_border=true&theme={theme}"
-        
-        file = await self.get_file_from_svg_url(url, exclude = [b"A++",b"A+"])
-        await ctx.send(file = discord.File(file,filename="stats.png"))
-        
-    @commands.command(name="githublanguages", aliases=["ghlangs", "ghtoplangs"])     
-    async def github_top_languages(self,ctx,username = "codewithswastik",theme="radical"):
+
+        file = await self.get_file_from_svg_url(url, exclude=[b"A++", b"A+"])
+        await ctx.send(file=discord.File(file, filename="stats.png"))
+
+    @commands.command(name="githublanguages", aliases=["ghlangs", "ghtoplangs"])
+    async def github_top_languages(
+        self, ctx, username="codewithswastik", theme="radical"
+    ):
         theme = theme.lower()
-        themes = "default dark radical merko gruvbox tokyonight onedark cobalt synthwave highcontrast dracula".split(" ")
+        themes = "default dark radical merko gruvbox tokyonight onedark cobalt synthwave highcontrast dracula".split(
+            " "
+        )
         if theme not in themes:
-            return await ctx.send("Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula")
-        url = "https://github-readme-stats.codestackr.vercel.app/api/top-langs/?" + urlencode(
-            {
-                "username": username,
-                "theme":theme
-            }
+            return await ctx.send(
+                "Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula"
+            )
+        url = (
+            "https://github-readme-stats.codestackr.vercel.app/api/top-langs/?"
+            + urlencode({"username": username, "theme": theme})
         )
         file = await self.get_file_from_svg_url(url)
-        await ctx.send(file = discord.File(file,filename="langs.png"))
-       
-    async def get_file_from_svg_url(self,url,exclude = [], fmt="PNG"):
+        await ctx.send(file=discord.File(file, filename="langs.png"))
+
+    async def get_file_from_svg_url(self, url, exclude=[], fmt="PNG"):
         res = await (await self.session.get(url)).content.read()
         for i in exclude:
-            res = res.replace(i,b"") #removes everything that needs to be excluded (eg. the uncentered A+)
+            res = res.replace(
+                i, b""
+            )  # removes everything that needs to be excluded (eg. the uncentered A+)
         drawing = svg2rlg(BytesIO(res))
         file = BytesIO(renderPM.drawToString(drawing, fmt=fmt))
         return file
-        
+    
     @staticmethod
     def repo_desc_format(result):
         description = result["description"]

--- a/bot/cogs/github.py
+++ b/bot/cogs/github.py
@@ -127,30 +127,28 @@ class Github(commands.Cog):
         
         
     @commands.command(name="githubstats", aliases=["ghstats", "ghst"])
-    async def github_stats(ctx,username = "codewithswastik",theme="radical"):
+    async def github_stats(self,ctx,username = "codewithswastik",theme="radical"):
         theme = theme.lower()
         themes = "default dark radical merko gruvbox tokyonight onedark cobalt synthwave highcontrast dracula".split(" ")
         if theme not in themes:
             return await ctx.send("Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula")
         url = f"https://github-readme-stats.codestackr.vercel.app/api?username={username}&show_icons=true&hide_border=true&theme={theme}"
         
-        
-        file = await getFileFromSVGURL(url, exclude = [b"A+"])
+        file = await self.get_file_from_svg_url(url, exclude = [b"A++",b"A+"])
         await ctx.send(file = discord.File(file,filename="stats.png"))
         
     @commands.command(name="githublanguages", aliases=["ghlangs", "ghtoplangs"])     
-    async def github_top_languages(ctx,username = "codewithswastik",theme="radical"):
+    async def github_top_languages(self,ctx,username = "codewithswastik",theme="radical"):
         theme = theme.lower()
         themes = "default dark radical merko gruvbox tokyonight onedark cobalt synthwave highcontrast dracula".split(" ")
         if theme not in themes:
             return await ctx.send("Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula")
         url = f"https://github-readme-stats.codestackr.vercel.app/api/top-langs/?username={username}&theme={theme}"
 
-        file = await getFileFromSVGURL(url)
+        file = await self.get_file_from_svg_url(url)
         await ctx.send(file = discord.File(file,filename="langs.png"))
- 
        
-    async def getFileFromSVGURL(url,exclude = [], fmt="PNG"):
+    async def get_file_from_svg_url(self,url,exclude = [], fmt="PNG"):
         res = await (await self.session.get(url)).content.read()
         for i in exclude:
             res = res.replace(i,b"") #removes everything that needs to be excluded (eg. the uncentered A+)

--- a/bot/cogs/github.py
+++ b/bot/cogs/github.py
@@ -132,6 +132,16 @@ class Github(commands.Cog):
         themes = "default dark radical merko gruvbox tokyonight onedark cobalt synthwave highcontrast dracula".split(" ")
         if theme not in themes:
             return await ctx.send("Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula")
+        url = "https://github-readme-stats.codestackr.vercel.app/api?" + urlencode(
+            {
+                "username": username,
+                "show_icons": "true",
+                "hide_border": "true",
+                "theme":theme
+            }
+        )
+        
+        
         url = f"https://github-readme-stats.codestackr.vercel.app/api?username={username}&show_icons=true&hide_border=true&theme={theme}"
         
         file = await self.get_file_from_svg_url(url, exclude = [b"A++",b"A+"])
@@ -143,8 +153,12 @@ class Github(commands.Cog):
         themes = "default dark radical merko gruvbox tokyonight onedark cobalt synthwave highcontrast dracula".split(" ")
         if theme not in themes:
             return await ctx.send("Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula")
-        url = f"https://github-readme-stats.codestackr.vercel.app/api/top-langs/?username={username}&theme={theme}"
-
+        url = "https://github-readme-stats.codestackr.vercel.app/api/top-langs/?" + urlencode(
+            {
+                "username": username,
+                "theme":theme
+            }
+        )
         file = await self.get_file_from_svg_url(url)
         await ctx.send(file = discord.File(file,filename="langs.png"))
        

--- a/bot/cogs/github.py
+++ b/bot/cogs/github.py
@@ -133,13 +133,30 @@ class Github(commands.Cog):
         if theme not in themes:
             return await ctx.send("Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula")
         url = f"https://github-readme-stats.codestackr.vercel.app/api?username={username}&show_icons=true&hide_border=true&theme={theme}"
-        res = await (await self.session.get(url)).content.read()
-
-        clean_res = res.replace(b"A+",b"") #removes the uncentered A+
-        drawing = svg2rlg(BytesIO(clean_res))
-        file = BytesIO(renderPM.drawToString(drawing, fmt="PNG"))
+        
+        
+        file = await getFileFromSVGURL(url, exclude = [b"A+"])
         await ctx.send(file = discord.File(file,filename="stats.png"))
+        
+    @commands.command(name="githublanguages", aliases=["ghlangs", "ghtoplangs"])     
+    async def github_top_languages(ctx,username = "codewithswastik",theme="radical"):
+        theme = theme.lower()
+        themes = "default dark radical merko gruvbox tokyonight onedark cobalt synthwave highcontrast dracula".split(" ")
+        if theme not in themes:
+            return await ctx.send("Not a valid theme. List of all valid themes:- default, dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula")
+        url = f"https://github-readme-stats.codestackr.vercel.app/api/top-langs/?username={username}&theme={theme}"
 
+        file = await getFileFromSVGURL(url)
+        await ctx.send(file = discord.File(file,filename="langs.png"))
+ 
+       
+    async def getFileFromSVGURL(url,exclude = [], fmt="PNG"):
+        res = await (await self.session.get(url)).content.read()
+        for i in exclude:
+            res = res.replace(i,b"") #removes everything that needs to be excluded (eg. the uncentered A+)
+        drawing = svg2rlg(BytesIO(res))
+        file = BytesIO(renderPM.drawToString(drawing, fmt=fmt))
+        return file
         
     @staticmethod
     def repo_desc_format(result):


### PR DESCRIPTION
I added the Github Stats and most used langauges command as per #4.

It requires [svglib](https://pypi.org/project/svglib) to function as the [response from the url](https://github-readme-stats.vercel.app/api?username=codewithswastik) is in an svg format. 

This hasn't been tested with aiohttp but it works with requests and should theoretically work with aiohttp too.